### PR TITLE
Removing automation from rest api module

### DIFF
--- a/healthvault-restapi/build.gradle
+++ b/healthvault-restapi/build.gradle
@@ -9,9 +9,6 @@ android {
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
-
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
     }
     buildTypes {
         release {
@@ -22,10 +19,6 @@ android {
 }
 
 dependencies {
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
-
     // Needed to compile auto generated code from AutoRest
     compile group: 'com.microsoft.rest', name: 'client-runtime', version: '1.0.2'
 


### PR DESCRIPTION
No need for automation in a library project with no ui. Unit tests are sufficient. Removing automation directory, package and dependencies.

Signed-off-by: Andrew Butler <anbutle@microsoft.com>